### PR TITLE
Add hasVRTour attribute to Ad and Card

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/ad/Ad.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/ad/Ad.java
@@ -10,10 +10,10 @@ public class Ad {
     private String advertiserId;
     private String description;
     private List<String> photosRefs;
-    private boolean hasVTour;
+    private boolean hasVRTour;
 
     public Ad(String title, String price, String address,
-              String advertiserId, String description, List<String> photosRefs, boolean hasVTour) {
+              String advertiserId, String description, List<String> photosRefs, boolean hasVRTour) {
         if (title == null || price == null || address == null)
             throw new IllegalArgumentException("An argument is null!");
         if (advertiserId == null || description == null || photosRefs == null)
@@ -25,7 +25,7 @@ public class Ad {
         this.address = address;
         this.description = description;
         this.photosRefs = photosRefs;
-        this.hasVTour = hasVTour;
+        this.hasVRTour = hasVRTour;
     }
 
     public Ad(String title, String price, String address,
@@ -57,7 +57,7 @@ public class Ad {
         return photosRefs;
     }
 
-    public boolean hasVTour() {
-        return hasVTour;
+    public boolean hasVRTour() {
+        return hasVRTour;
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/ad/Ad.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/ad/Ad.java
@@ -1,0 +1,63 @@
+package ch.epfl.sdp.appart.scrolling.ad;
+
+import java.util.List;
+
+public class Ad {
+
+    private String title;
+    private String price;
+    private String address;
+    private String advertiserId;
+    private String description;
+    private List<String> photosRefs;
+    private boolean hasVTour;
+
+    public Ad(String title, String price, String address,
+              String advertiserId, String description, List<String> photosRefs, boolean hasVTour) {
+        if (title == null || price == null || address == null)
+            throw new IllegalArgumentException("An argument is null!");
+        if (advertiserId == null || description == null || photosRefs == null)
+            throw new IllegalArgumentException("An argument is null!");
+
+        this.title = title;
+        this.price = price;
+        this.advertiserId = advertiserId;
+        this.address = address;
+        this.description = description;
+        this.photosRefs = photosRefs;
+        this.hasVTour = hasVTour;
+    }
+
+    public Ad(String title, String price, String address,
+              String advertiserId, String description, List<String> photosRefs) {
+        this(title, price, address, advertiserId, description, photosRefs, false);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getAdvertiserId() {
+        return advertiserId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<String> getPhotosRefs() {
+        return photosRefs;
+    }
+
+    public boolean hasVTour() {
+        return hasVTour;
+    }
+}

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/Card.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/Card.java
@@ -8,12 +8,14 @@ public class Card {
     private String city;
     private long price;
     private String imageUrl;
+    private boolean hasVTour;
 
     /*
      * A newly created card will be local, hence the id won't be assigned (null). At the first
      * upload to Firestore, a new unique id will be generated and assigned to the card.
      */
-    public Card(@Nullable String id, String ownerId, String city, long price, String imageUrl) {
+    public Card(@Nullable String id, String ownerId, String city, long price, String imageUrl,
+                boolean hasVTour) {
         if (ownerId == null || city == null || imageUrl == null)
             throw new IllegalArgumentException("Argument is null!");
 
@@ -22,6 +24,11 @@ public class Card {
         this.city = city;
         this.price = price;
         this.imageUrl = imageUrl;
+        this.hasVTour = hasVTour;
+    }
+
+    public Card(@Nullable String id, String ownerId, String city, long price, String imageUrl) {
+        this(id, ownerId, city, price, imageUrl, false);
     }
 
     // Getter Setter
@@ -59,6 +66,10 @@ public class Card {
     public String getUserId() {
         return ownerId;
     }
+
+    public boolean hasVTour(){ return hasVTour; }
+
+    public void setVTour(boolean b) { hasVTour = b; }
 
     private void nullChecker(Object o) {
         if (o == null)

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/Card.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/Card.java
@@ -8,14 +8,14 @@ public class Card {
     private String city;
     private long price;
     private String imageUrl;
-    private boolean hasVTour;
+    private boolean hasVRTour;
 
     /*
      * A newly created card will be local, hence the id won't be assigned (null). At the first
      * upload to Firestore, a new unique id will be generated and assigned to the card.
      */
     public Card(@Nullable String id, String ownerId, String city, long price, String imageUrl,
-                boolean hasVTour) {
+                boolean hasVRTour) {
         if (ownerId == null || city == null || imageUrl == null)
             throw new IllegalArgumentException("Argument is null!");
 
@@ -24,7 +24,7 @@ public class Card {
         this.city = city;
         this.price = price;
         this.imageUrl = imageUrl;
-        this.hasVTour = hasVTour;
+        this.hasVRTour = hasVRTour;
     }
 
     public Card(@Nullable String id, String ownerId, String city, long price, String imageUrl) {
@@ -67,9 +67,9 @@ public class Card {
         return ownerId;
     }
 
-    public boolean hasVTour(){ return hasVTour; }
+    public boolean hasVRTour(){ return hasVRTour; }
 
-    public void setVTour(boolean b) { hasVTour = b; }
+    public void setVRTour(boolean b) { hasVRTour = b; }
 
     private void nullChecker(Object o) {
         if (o == null)

--- a/app/src/test/java/ch/epfl/sdp/appart/AdUnitTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/AdUnitTest.java
@@ -1,0 +1,115 @@
+package ch.epfl.sdp.appart;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.epfl.sdp.appart.scrolling.ad.Ad;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class AdUnitTest {
+
+    private Ad ad;
+
+    @Before
+    public void setup(){
+        List<String> refs = new ArrayList<>();
+        refs.add("ref");
+        ad = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
+                "unknown", "Cool place", refs);
+    }
+
+
+    @Test
+    public void exceptionOnNullArg1(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad(null, "1000 / mo", "Station 18, 1015 Lausanne",
+                    "unknown", "Cool place", new ArrayList<String>());
+        });
+    }
+
+    @Test
+    public void exceptionOnNullArg2(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad("Ad title", null, "Station 18, 1015 Lausanne",
+                    "unknown", "Cool place", new ArrayList<String>());
+        });
+    }
+
+    @Test
+    public void exceptionOnNullArg3(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad("Ad title", "1000 / mo", null,
+                    "unknown", "Cool place", new ArrayList<String>());
+        });
+    }
+
+    @Test
+    public void exceptionOnNullArg4(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
+                    null, "Cool place", new ArrayList<String>());
+        });
+    }
+
+    @Test
+    public void exceptionOnNullArg5(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
+                    "unknown", null, new ArrayList<String>());
+        });
+    }
+
+    @Test
+    public void exceptionOnNullArg6(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            Ad failAD = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
+                    "unknown", "Cool place", null);
+        });
+    }
+
+    @Test
+    public void titleGetterTest(){
+        assertEquals("Ad title", ad.getTitle());
+    }
+
+    @Test
+    public void priceGetterTest(){
+        assertEquals("1000 / mo", ad.getPrice());
+    }
+
+    @Test
+    public void addressGetterTest(){
+        assertEquals("Station 18, 1015 Lausanne", ad.getAddress());
+    }
+
+    @Test
+    public void advertiserGetterTest(){
+        assertEquals("unknown", ad.getAdvertiserId());
+    }
+
+    @Test
+    public void descriptionGetterTest(){
+        assertEquals("Cool place", ad.getDescription());
+    }
+
+    @Test
+    public void photosrefsGetterTest(){
+        List<String> refs = new ArrayList<>();
+        refs.add("ref");
+        assertEquals(refs, ad.getPhotosRefs());
+    }
+
+    @Test
+    public void hsaVTourGetterTest(){
+        List<String> refs = new ArrayList<>();
+        refs.add("ref");
+        ad = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
+                "unknown", "Cool place", refs, true);
+        assertEquals(true, ad.hasVTour());
+    }
+}

--- a/app/src/test/java/ch/epfl/sdp/appart/AdUnitTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/AdUnitTest.java
@@ -110,6 +110,6 @@ public class AdUnitTest {
         refs.add("ref");
         ad = new Ad("Ad title", "1000 / mo", "Station 18, 1015 Lausanne",
                 "unknown", "Cool place", refs, true);
-        assertEquals(true, ad.hasVTour());
+        assertEquals(true, ad.hasVRTour());
     }
 }

--- a/app/src/test/java/ch/epfl/sdp/appart/CardUnitTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/CardUnitTest.java
@@ -13,12 +13,14 @@ public class CardUnitTest {
 
     @Test
     public void gettersTest() {
-        Card card = new Card(null, "user", "Lausanne", 900, "assets/img1.jpg");
+        Card card = new Card(null, "user", "Lausanne", 900,
+                "assets/img1.jpg", true);
         assertNull(card.getId());
         assertEquals("Lausanne", card.getCity());
         assertEquals(900, card.getPrice());
         assertEquals("assets/img1.jpg", card.getImageUrl());
         assertEquals("user", card.getUserId());
+        assertEquals(true, card.hasVTour());
     }
 
     @Test
@@ -30,6 +32,8 @@ public class CardUnitTest {
         assertEquals(850, card.getPrice());
         card.setImageUrl("assets/img2.jpg");
         assertEquals("assets/img2.jpg", card.getImageUrl());
+        card.setVTour(true);
+        assertEquals(true, card.hasVTour());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/app/src/test/java/ch/epfl/sdp/appart/CardUnitTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/CardUnitTest.java
@@ -20,7 +20,7 @@ public class CardUnitTest {
         assertEquals(900, card.getPrice());
         assertEquals("assets/img1.jpg", card.getImageUrl());
         assertEquals("user", card.getUserId());
-        assertEquals(true, card.hasVTour());
+        assertEquals(true, card.hasVRTour());
     }
 
     @Test
@@ -32,8 +32,8 @@ public class CardUnitTest {
         assertEquals(850, card.getPrice());
         card.setImageUrl("assets/img2.jpg");
         assertEquals("assets/img2.jpg", card.getImageUrl());
-        card.setVTour(true);
-        assertEquals(true, card.hasVTour());
+        card.setVRTour(true);
+        assertEquals(true, card.hasVRTour());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR adds an attribute that tells whether the ad supports a virtual tour.
This makes a base modification for other tasks in this sprint.

It already adds the Ad class and its unit tests, which are present in #68. If no changes on Ad and AdUnitTest are made after 1188ff5 in that branch, then keep this version when resolving merge conflicts.