### PR TITLE
Tidy up firebase firestore/storage and change paths in up/down-load of images

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -69,10 +69,6 @@ public class DatabaseTest {
         assertThat(retrievedCard.getUserId(), is(ownerID));
     }
 
-    public void putCardThrowsOnNull() {
-        assertThrows(IllegalArgumentException.class, () -> db.putCard(null));
-    }
-
     public void verifyUser(User retrievedUser, long age, String name, String id, String email, String phoneNB) {
         assertThat(retrievedUser.getUserEmail(), is(email));
         assertThat(retrievedUser.getName(), is(name));
@@ -207,45 +203,10 @@ public class DatabaseTest {
 
     }
 
-    public void putCardTest() {
-        String id = "fakeId";
-        String adId = "fakeAdId";
-        String ownerId = "fakeOwnerID";
-        String city = "fakeCity";
-        long price = 1000;
-        boolean hasVRTour = false;
-
-        Card card = new Card(id, adId, ownerId, city, price, "", hasVRTour);
-
-        List<Card> cards = db.getCards().join();
-        assertThat(cards.size(), is(1));
-
-        String otherCardId = cards.get(0).getId();
-
-        String cardId = db.putCard(card).join();
-
-        cards = db.getCards().join();
-
-        Card wantedCard = null;
-        for (Card retrievedCard : cards) {
-            if (retrievedCard.getId().equals(id) || !retrievedCard.getId().equals(otherCardId) || retrievedCard.getId().equals(cardId)) {
-                wantedCard = retrievedCard;
-                break;
-            }
-        }
-
-        assertNotNull(wantedCard);
-
-        verifyCard(wantedCard, city, price, ownerId);
-
-    }
-
     @Test
     public void databaseTest() throws IOException {
         addingUsersAndUpdateTest();
         addingAdAndGetTest();
-        putCardThrowsOnNull();
         updateCardTest();
-        putCardTest();
     }
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -20,6 +20,7 @@ import ch.epfl.sdp.appart.ad.ContactInfo;
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.FirestoreDatabaseService;
 import ch.epfl.sdp.appart.database.FirestoreEmulatorDatabaseServiceWrapper;
+import ch.epfl.sdp.appart.database.firestorelayout.AdLayout;
 import ch.epfl.sdp.appart.hilt.DatabaseModule;
 import ch.epfl.sdp.appart.hilt.LoginModule;
 import ch.epfl.sdp.appart.login.FirebaseEmulatorLoginServiceWrapper;
@@ -49,7 +50,7 @@ public class DatabaseTest {
 
     @BindValue
     final
-    DatabaseService db = new FirestoreEmulatorDatabaseServiceWrapper(new FirestoreDatabaseService());
+    FirestoreEmulatorDatabaseServiceWrapper db = new FirestoreEmulatorDatabaseServiceWrapper(new FirestoreDatabaseService());
 
     @BindValue
     final
@@ -132,7 +133,6 @@ public class DatabaseTest {
     }
 
     public void addingAdAndGetTest() throws IOException {
-        // TODO remove photo after upload
         Ad.AdBuilder builder = new Ad.AdBuilder();
 
         String title = "Test ad";
@@ -168,7 +168,7 @@ public class DatabaseTest {
         builder.hasVRTour(hasVRTour);
 
         Ad ad = builder.build();
-        db.putAd(ad, uriList).join();
+        String adId = db.putAd(ad, uriList).join();
 
         List<Card> retrievedCards = this.db.getCards().join();
         assertThat(retrievedCards.size(), is(1));
@@ -179,7 +179,7 @@ public class DatabaseTest {
         Ad retrievedAd = db.getAd(card.getId()).join();
         verifyAd(retrievedAd, title, street, city, desc, price, globalUser.getUserId(), contactInfo, pricePeriod, hasVRTour);
 
-
+        db.removeFromStorage(db.getStorageReference(AdLayout.DIRECTORY + "/" + adId));
     }
 
     public void updateCardTest() {
@@ -207,7 +207,7 @@ public class DatabaseTest {
     @Test
     public void databaseTest() throws IOException {
         addingUsersAndUpdateTest();
-        // addingAdAndGetTest();
+        addingAdAndGetTest();
         updateCardTest();
     }
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -50,16 +50,18 @@ public class DatabaseTest {
 
     @BindValue
     final
-    FirestoreEmulatorDatabaseServiceWrapper db = new FirestoreEmulatorDatabaseServiceWrapper(new FirestoreDatabaseService());
+    DatabaseService db = new FirestoreEmulatorDatabaseServiceWrapper(new FirestoreDatabaseService());
 
     @BindValue
     final
     LoginService loginService = new FirebaseEmulatorLoginServiceWrapper(new FirebaseLoginService());
 
     User globalUser = null;
+    FirestoreEmulatorDatabaseServiceWrapper database;
 
     @Before
     public void setup() {
+        database = (FirestoreEmulatorDatabaseServiceWrapper) db;
         db.clearCache().join();
         System.out.println("Cache cleared");
     }
@@ -179,7 +181,7 @@ public class DatabaseTest {
         Ad retrievedAd = db.getAd(card.getId()).join();
         verifyAd(retrievedAd, title, street, city, desc, price, globalUser.getUserId(), contactInfo, pricePeriod, hasVRTour);
 
-        db.removeFromStorage(db.getStorageReference(AdLayout.DIRECTORY + "/" + adId));
+        database.removeFromStorage(database.getStorageReference(AdLayout.DIRECTORY + "/" + adId));
     }
 
     public void updateCardTest() {

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -113,7 +113,8 @@ public class DatabaseTest {
         retrievedUser = db.getUser(user.getUserId()).join();
 
         verifyUser(retrievedUser, age, name, userId, email, phoneNb);
-        */globalUser = retrievedUser;
+        */
+        globalUser = retrievedUser;
     }
 
     public void verifyAd(Ad retrievedAd, String title, String street, String city, String desc, long price, String advertiserId, ContactInfo contactInfo, PricePeriod pricePeriod, boolean hasVRTour) {
@@ -181,7 +182,7 @@ public class DatabaseTest {
         Ad retrievedAd = db.getAd(card.getId()).join();
         verifyAd(retrievedAd, title, street, city, desc, price, globalUser.getUserId(), contactInfo, pricePeriod, hasVRTour);
 
-        database.removeFromStorage(database.getStorageReference(AdLayout.DIRECTORY + "/" + adId));
+        database.removeFromStorage(database.getStorageReference(AdLayout.DIRECTORY + "/" + adId + "photo0.jpeg"));
     }
 
     public void updateCardTest() {

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -132,6 +132,7 @@ public class DatabaseTest {
     }
 
     public void addingAdAndGetTest() throws IOException {
+        // TODO remove photo after upload
         Ad.AdBuilder builder = new Ad.AdBuilder();
 
         String title = "Test ad";
@@ -206,7 +207,7 @@ public class DatabaseTest {
     @Test
     public void databaseTest() throws IOException {
         addingUsersAndUpdateTest();
-        addingAdAndGetTest();
+        // addingAdAndGetTest();
         updateCardTest();
     }
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/DatabaseTest.java
@@ -20,7 +20,8 @@ import ch.epfl.sdp.appart.ad.ContactInfo;
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.FirestoreDatabaseService;
 import ch.epfl.sdp.appart.database.FirestoreEmulatorDatabaseServiceWrapper;
-import ch.epfl.sdp.appart.database.firestorelayout.AdLayout;
+import ch.epfl.sdp.appart.database.firebaselayout.AdLayout;
+import ch.epfl.sdp.appart.database.firebaselayout.FirebaseLayout;
 import ch.epfl.sdp.appart.hilt.DatabaseModule;
 import ch.epfl.sdp.appart.hilt.LoginModule;
 import ch.epfl.sdp.appart.login.FirebaseEmulatorLoginServiceWrapper;
@@ -182,7 +183,8 @@ public class DatabaseTest {
         Ad retrievedAd = db.getAd(card.getId()).join();
         verifyAd(retrievedAd, title, street, city, desc, price, globalUser.getUserId(), contactInfo, pricePeriod, hasVRTour);
 
-        database.removeFromStorage(database.getStorageReference(AdLayout.DIRECTORY + "/" + adId + "photo0.jpeg"));
+        database.removeFromStorage(database.getStorageReference(
+                FirebaseLayout.ADS_DIRECTORY + FirebaseLayout.SEPARATOR + adId + "photo0.jpeg"));
     }
 
     public void updateCardTest() {

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
@@ -54,15 +54,11 @@ public class PanoramaUITest {
     }
 
     @Test
-    public void buttonVisibilityOnFirstImageTest() {
+    public void buttonVisibilityTest() {
         onView(withId(leftButtonID)).check(matches(not(isDisplayed())));
         onView(withId(rightButtonID)).check(matches(isDisplayed()));
-    }
 
-    @Test
-    public void buttonVisibilityOnSecondImageTest() {
         onView(withId(rightButtonID)).perform(click());
-
         onView(withId(leftButtonID)).check(matches(isDisplayed()));
         onView(withId(rightButtonID)).check(matches(not(isDisplayed())));
     }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
@@ -61,6 +61,11 @@ public class PanoramaUITest {
         onView(withId(rightButtonID)).perform(click());
         onView(withId(leftButtonID)).check(matches(isDisplayed()));
         onView(withId(rightButtonID)).check(matches(not(isDisplayed())));
+
+        onView(withId(leftButtonID)).perform(click());
+        onView(withId(leftButtonID)).check(matches(not(isDisplayed())));
+        onView(withId(rightButtonID)).check(matches(isDisplayed()));
+
     }
 
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 
 import ch.epfl.sdp.appart.ad.AdViewModel;
 import ch.epfl.sdp.appart.database.DatabaseService;
-import ch.epfl.sdp.appart.database.firestorelayout.AdLayout;
+import ch.epfl.sdp.appart.database.firebaselayout.FirebaseLayout;
 import ch.epfl.sdp.appart.glide.visitor.GlideImageViewLoader;
 import ch.epfl.sdp.appart.login.LoginService;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -82,8 +82,9 @@ public class AdActivity extends ToolbarActivity {
                     (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             View myView = inflater.inflate(R.layout.photo_layout, (ViewGroup) null);
             ImageView photo = myView.findViewById(R.id.photo_Photo_imageView);
+            String sep = FirebaseLayout.SEPARATOR;
             database.accept(new GlideImageViewLoader(this, photo,
-                    AdLayout.DIRECTORY + "/" + adId + "/" + references.get(i)));
+                    FirebaseLayout.ADS_DIRECTORY + sep + adId + sep + references.get(i)));
             horizontalLayout.addView(myView);
             if (i != 4) {
                 Space hspacer = new Space(this);

--- a/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 
 import ch.epfl.sdp.appart.ad.AdViewModel;
 import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.database.firestorelayout.AdLayout;
 import ch.epfl.sdp.appart.glide.visitor.GlideImageViewLoader;
 import ch.epfl.sdp.appart.login.LoginService;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -34,6 +35,7 @@ public class AdActivity extends ToolbarActivity {
     DatabaseService database;
     @Inject
     LoginService login;
+    String adId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,7 +64,8 @@ public class AdActivity extends ToolbarActivity {
             mViewModel.initAd(getIntent().getStringExtra("adID"));
         }
         */
-        mViewModel.initAd(getIntent().getStringExtra("adID"));
+        adId = getIntent().getStringExtra("adID");
+        mViewModel.initAd(getIntent().getStringExtra("cardID"));
     }
 
     private void updateTitle(String title) {
@@ -80,7 +83,7 @@ public class AdActivity extends ToolbarActivity {
             View myView = inflater.inflate(R.layout.photo_layout, (ViewGroup) null);
             ImageView photo = myView.findViewById(R.id.photo_Photo_imageView);
             database.accept(new GlideImageViewLoader(this, photo,
-                    references.get(i)));
+                    AdLayout.DIRECTORY + "/" + adId + "/" + references.get(i)));
             horizontalLayout.addView(myView);
             if (i != 4) {
                 Space hspacer = new Space(this);

--- a/app/src/main/java/ch/epfl/sdp/appart/AdCreationActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/AdCreationActivity.java
@@ -89,6 +89,7 @@ public class AdCreationActivity extends AppCompatActivity {
         setVMValues();
 
         // confirm creation and elaborate result
+        // TODO show a loading box and disable modifiying field / click buttons -> maybe a loading screen?
         CompletableFuture<Boolean> result = mViewModel.confirmCreation();
         result.thenAccept(completed -> {
             if (completed) {

--- a/app/src/main/java/ch/epfl/sdp/appart/database/DatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/DatabaseService.java
@@ -31,19 +31,6 @@ public interface DatabaseService extends DatabaseHostVisitor {
     CompletableFuture<List<Card>> getCards();
 
     /**
-     * Store the card given as argument in the database.
-     *
-     * @param card the Card that will be stored
-     * @return A future that wraps a String representing
-     * the new id of the card stored on the database. If an error
-     * occurs, the future will complete exceptionally by holding a
-     * DatabaseServiceException.
-     * @throws IllegalArgumentException if card is null.
-     */
-    @NonNull
-    CompletableFuture<String> putCard(@NonNull Card card);
-
-    /**
      * Update the card given as argument in the database.
      *
      * @param card the Card that will be updated in the database

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
@@ -215,7 +215,7 @@ public class FirestoreDatabaseService implements DatabaseService {
     }
 
     private CompletableFuture<Boolean> updateUserDb(CompletableFuture<Boolean> res, User user){
-            db.collection(UserLayout.DIRECTORY)
+            db.collection(FirebaseLayout.USERS_DIRECTORY)
                     .document(user.getUserId())
                     .set(extractUserInfo(user))
                     .addOnCompleteListener(

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
@@ -518,7 +518,7 @@ public class FirestoreDatabaseService implements DatabaseService {
                 QuerySnapshot snapshot = task.getResult();
                 List<DocumentSnapshot> documentSnapshots = snapshot.getDocuments();
                 List<String> result = documentSnapshots.stream().map(documentSnapshot ->
-                        AdLayout.DIRECTORY + documentSnapshot.get("id")).collect(Collectors.toList());
+                        (String) documentSnapshot.get("id")).collect(Collectors.toList());
                 photosReferencesListFuture.complete(result);
             } else {
                 photosReferencesListFuture.completeExceptionally(

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
@@ -287,9 +287,6 @@ public class FirestoreDatabaseService implements DatabaseService {
             String name = "photo" + i + ".jpeg"; // TODO modify to support other extensions
             actualRefs.add(name);
             imagesUploadResults.add(putImage(uriList.get(i), name, AdLayout.DIRECTORY + "/" + newAdRef.getId()));
-            if (i == 0) {
-                imagesUploadResults.add(putImage(uriList.get(0), name, CardLayout.DIRECTORY));
-            }
         }
         // check whether any of the uploads failed TODO check
         //checkPhotosUpload(imagesUploadResults, imagesResult, newAdRef, cardRef, storageRef);

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
@@ -339,7 +339,7 @@ public class FirestoreDatabaseService implements DatabaseService {
             cardRef.delete();
             imagesRef.listAll().addOnSuccessListener(listResult -> {
                 List<StorageReference> items = listResult.getItems();
-                for (StorageReference item : items){
+                for (StorageReference item : items) {
                     item.delete();
                 }
             }).addOnFailureListener(e -> Log.d("Ad upload", "Failed to cleanup after failed upload"));

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreDatabaseService.java
@@ -451,6 +451,15 @@ public class FirestoreDatabaseService implements DatabaseService {
     }
 
     /**
+     * Utility function to clean up storage database
+     *
+     * @param ref reference to the folder/file to delete
+     */
+    public void removeFromStorage(StorageReference ref) {
+        ref.delete();
+    }
+
+    /**
      * Takes a cardId and fetch the adId for the corresponding card.
      * Indeed, all the cards that are showed in the scrolling menu
      * refers to an ad by an AdId. So in order to query the right

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreEmulatorDatabaseServiceWrapper.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreEmulatorDatabaseServiceWrapper.java
@@ -1,7 +1,10 @@
 package ch.epfl.sdp.appart.database;
 
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
+
+import com.google.firebase.storage.StorageReference;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -81,11 +84,21 @@ public class FirestoreEmulatorDatabaseServiceWrapper implements DatabaseService 
 
     @NonNull
     @Override
-    public CompletableFuture<Boolean> putImage(Uri uri, String name, String path) { return db.putImage(uri, name, path); }
+    public CompletableFuture<Boolean> putImage(Uri uri, String name, String path) {
+        return db.putImage(uri, name, path);
+    }
 
     @Override
     public CompletableFuture<Void> clearCache() {
         return db.clearCache();
+    }
+
+    public void removeFromStorage(StorageReference ref) {
+        db.removeFromStorage(ref);
+    }
+
+    public StorageReference getStorageReference(String path){
+        return db.getStorageReference(path);
     }
 
     @Override
@@ -99,5 +112,7 @@ public class FirestoreEmulatorDatabaseServiceWrapper implements DatabaseService 
     }
 
     @Override
-    public void accept(GlideLoaderListenerVisitor visitor) { db.accept(visitor); }
+    public void accept(GlideLoaderListenerVisitor visitor) {
+        db.accept(visitor);
+    }
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreEmulatorDatabaseServiceWrapper.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/FirestoreEmulatorDatabaseServiceWrapper.java
@@ -40,13 +40,6 @@ public class FirestoreEmulatorDatabaseServiceWrapper implements DatabaseService 
     @NotNull
     @NonNull
     @Override
-    public CompletableFuture<String> putCard(@NotNull @NonNull Card card) {
-        return this.db.putCard(card);
-    }
-
-    @NotNull
-    @NonNull
-    @Override
     public CompletableFuture<Boolean> updateCard(@NotNull @NonNull Card card) {
         return db.updateCard(card);
     }

--- a/app/src/main/java/ch/epfl/sdp/appart/database/MockDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/MockDatabaseService.java
@@ -73,15 +73,6 @@ public class MockDatabaseService implements DatabaseService {
 
     @NotNull
     @Override
-    public CompletableFuture<String> putCard(@NotNull Card card) {
-        CompletableFuture<String> result = new CompletableFuture<>();
-        cards.add(card);
-        result.complete(card.getId());
-        return result;
-    }
-
-    @NotNull
-    @Override
     public CompletableFuture<Boolean> updateCard(@NotNull Card card) {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         if (cards.contains(card)) {

--- a/app/src/main/java/ch/epfl/sdp/appart/database/MockDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/MockDatabaseService.java
@@ -32,11 +32,11 @@ public class MockDatabaseService implements DatabaseService {
 
     public MockDatabaseService() {
 
-        cards.add(new Card("unknown", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
-        cards.add(new Card("unknown", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
-        cards.add(new Card("unknown", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
-        cards.add(new Card("unknown", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
-        cards.add(new Card("unknown", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
+        cards.add(new Card("unknown1", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
+        cards.add(new Card("unknown2", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
+        cards.add(new Card("unknown3", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
+        cards.add(new Card("unknown4", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
+        cards.add(new Card("unknown5", "unknown", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg"));
 
         List<String> picturesReferences = Arrays.asList(
                 "file:///android_asset/fake_ad_1.jpg",

--- a/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/AdLayout.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/AdLayout.java
@@ -1,4 +1,4 @@
-package ch.epfl.sdp.appart.database.firestorelayout;
+package ch.epfl.sdp.appart.database.firebaselayout;
 
 /**
  * Un-instantiable Holder for the layout of the fields for an Ad on Firestore.
@@ -9,11 +9,6 @@ public final class AdLayout {
     //WARNING : ref -> id
 
     private AdLayout() {}
-
-    /**
-     * absolute path to the ads directory in Firestore
-     */
-    public final static String DIRECTORY = "ads";
 
     /**
      * absolute path to the pictures directory of the ad in Firestore

--- a/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/CardLayout.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/CardLayout.java
@@ -1,4 +1,4 @@
-package ch.epfl.sdp.appart.database.firestorelayout;
+package ch.epfl.sdp.appart.database.firebaselayout;
 
 /**
  * Un-instantiable Holder for the layout of the fields for a Card on Firestore.
@@ -9,15 +9,9 @@ public final class CardLayout {
     }
 
     /**
-     * absolute path to the cards directory in Firestore
-     */
-    public final static String DIRECTORY = "cards";
-
-    /**
      * absolute path to the folder containing the card image
      */
     public final static String IMAGE_DIRECTORY = "ads";
-
 
     /**
      * absolute path to the cards directory in Firestore

--- a/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/FirebaseLayout.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/FirebaseLayout.java
@@ -1,0 +1,34 @@
+package ch.epfl.sdp.appart.database.firebaselayout;
+
+/**
+ * Un-instantiable Holder for the layout of FIrebase Storage and Firestore.
+ */
+public final class FirebaseLayout {
+
+    private FirebaseLayout(){}
+
+    /**
+     * Name of the ads directory in Firebase Storage and Firestore
+     */
+    public static final String ADS_DIRECTORY = "ads";
+
+    /**
+     * Name of the ads directory in Firebase Storage and Firestore
+     */
+    public static final String CARDS_DIRECTORY = "cards";
+
+    /**
+     * Name of the users directory in Firebase Storage and Firestore
+     */
+    public static final String USERS_DIRECTORY = "users";
+
+    /**
+     * Default name of photo added to FirebaseStorage
+     */
+    public static final String PHOTO_NAME = "Photo";
+
+    /**
+     * Separator to concatenate paths
+     */
+    public static final String SEPARATOR = "/";
+}

--- a/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/UserLayout.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/firebaselayout/UserLayout.java
@@ -1,4 +1,4 @@
-package ch.epfl.sdp.appart.database.firestorelayout;
+package ch.epfl.sdp.appart.database.firebaselayout;
 
 /**
  * Un-instantiable Holder for the layout of the fields for a User on Firestore.
@@ -7,11 +7,6 @@ public final class UserLayout {
 
     private UserLayout() {
     }
-
-    /**
-     * absolute path to the users directory in Firestore
-     */
-    public final static String DIRECTORY = "users";
 
     /**
      * @apiNote : long on Firestore

--- a/app/src/main/java/ch/epfl/sdp/appart/database/firestorelayout/CardLayout.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/firestorelayout/CardLayout.java
@@ -14,6 +14,12 @@ public final class CardLayout {
     public final static String DIRECTORY = "cards";
 
     /**
+     * absolute path to the folder containing the card image
+     */
+    public final static String IMAGE_DIRECTORY = "ads";
+
+
+    /**
      * absolute path to the cards directory in Firestore
      */
     public final static String AD_ID = "ad_id"; //adId

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
@@ -13,12 +13,12 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
-import java.util.Locale;
 
 import ch.epfl.sdp.appart.AdActivity;
 import ch.epfl.sdp.appart.R;
 import ch.epfl.sdp.appart.database.DatabaseService;
-import ch.epfl.sdp.appart.database.firestorelayout.CardLayout;
+import ch.epfl.sdp.appart.database.firebaselayout.CardLayout;
+import ch.epfl.sdp.appart.database.firebaselayout.FirebaseLayout;
 import ch.epfl.sdp.appart.glide.visitor.GlideImageViewLoader;
 
 /**
@@ -86,8 +86,9 @@ public class CardAdapter extends RecyclerView.Adapter<CardAdapter.CardViewHolder
         });
 
         // load image from database into ImageView
+        String sep = FirebaseLayout.SEPARATOR;
         database.accept(new GlideImageViewLoader(context, holder.cardImageView,
-                CardLayout.IMAGE_DIRECTORY + "/" + card.getAdId() + "/" + card.getImageUrl()));
+                CardLayout.IMAGE_DIRECTORY + sep + card.getAdId() + sep + card.getImageUrl()));
         holder.addressTextView.setText(card.getCity());
         holder.priceTextView.setText(String.format("%d.-/mo", card.getPrice()));
         if (!card.hasVRTour())

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
@@ -80,7 +80,8 @@ public class CardAdapter extends RecyclerView.Adapter<CardAdapter.CardViewHolder
         holder.cardImageView.setOnClickListener(v -> {
             Intent intent = new Intent(context, AdActivity.class);
             intent.putExtra("fromAdCreation", false);
-            intent.putExtra("adID", card.getId());
+            intent.putExtra("cardID", card.getId());
+            intent.putExtra("adID", card.getAdId());
             context.startActivity(intent);
         });
 

--- a/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/scrolling/card/CardAdapter.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import ch.epfl.sdp.appart.AdActivity;
 import ch.epfl.sdp.appart.R;
 import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.database.firestorelayout.CardLayout;
 import ch.epfl.sdp.appart.glide.visitor.GlideImageViewLoader;
 
 /**
@@ -85,7 +86,7 @@ public class CardAdapter extends RecyclerView.Adapter<CardAdapter.CardViewHolder
 
         // load image from database into ImageView
         database.accept(new GlideImageViewLoader(context, holder.cardImageView,
-                "Cards/" + card.getImageUrl()));
+                CardLayout.IMAGE_DIRECTORY + "/" + card.getAdId() + "/" + card.getImageUrl()));
         holder.addressTextView.setText(card.getCity());
         holder.priceTextView.setText(String.format("%d.-/mo", card.getPrice()));
         if (!card.hasVRTour())

--- a/app/src/test/java/ch/epfl/sdp/appart/MockDatabaseTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/MockDatabaseTest.java
@@ -16,6 +16,7 @@ import ch.epfl.sdp.appart.database.MockDatabaseService;
 import ch.epfl.sdp.appart.scrolling.card.Card;
 import ch.epfl.sdp.appart.user.AppUser;
 import ch.epfl.sdp.appart.user.User;
+import kotlin.NotImplementedError;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -44,14 +45,15 @@ public class MockDatabaseTest {
 
     @Test
     public void addCardAndUpdateToDatabase() {
-        Card test = new Card("unknown2", "unknown2", "unknown2", "Lausanne2", 10000, "file:///android_asset/apart_fake_image_1.jpeg");
+        throw new NotImplementedError("Redefine test for updateCard!");
+        /*Card test = new Card("unknown2", "unknown2", "unknown2", "Lausanne2", 10000, "file:///android_asset/apart_fake_image_1.jpeg");
         try {
             assertFalse(dataBase.updateCard(test).get());
             assertEquals("unknown2", dataBase.putCard(test).get());
             assertTrue(dataBase.updateCard(test).get());
         } catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
-        }
+        }*/
 
     }
 

--- a/app/src/test/java/ch/epfl/sdp/appart/MockDatabaseTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/MockDatabaseTest.java
@@ -44,17 +44,23 @@ public class MockDatabaseTest {
     }
 
     @Test
-    public void addCardAndUpdateToDatabase() {
-        throw new NotImplementedError("Redefine test for updateCard!");
-        /*Card test = new Card("unknown2", "unknown2", "unknown2", "Lausanne2", 10000, "file:///android_asset/apart_fake_image_1.jpeg");
+    public void updateCorrectCard() {
+        Card test = new Card("unknown1", "adId", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg");
         try {
-            assertFalse(dataBase.updateCard(test).get());
-            assertEquals("unknown2", dataBase.putCard(test).get());
             assertTrue(dataBase.updateCard(test).get());
         } catch (ExecutionException | InterruptedException e) {
             e.printStackTrace();
-        }*/
+        }
+    }
 
+    @Test
+    public void updateWrongCard() {
+        Card test = new Card("unknown6", "adId", "unknown", "Lausanne", 1000, "file:///android_asset/apart_fake_image_1.jpeg");
+        try {
+            assertFalse(dataBase.updateCard(test).get());
+        } catch (ExecutionException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR closes #155 .

It modifies various classes to make sure images are uploaded at the right place and downloaded from the right place. Now the card images are downloaded from the ads images folder, to save some space.

It removes `putCard` from `DatabaseService`s since `putAd` already deals with uploading the card.

It modifies testing for `DatabaseService`:
- remove image after uploading to Storage because of `putAd`
- remove testing of `putCard`

It adds a `FirebaseLayout` class that stores the directories names for all Firebase data, and removed these fields from the relative objects Layout classes.

---

Known issues:
- you cannot programmatically delete a folder in Storage, so the test ad folders aren't deleted from firebase storage
- testing the panorama activity is very unreliable on cirrus, this is probably caused by panoramagl and loading the panorama images