### PR TITLE
Remove back button from activities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
+    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     implementation platform('com.google.firebase:firebase-bom:26.6.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-auth'

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/AdUITest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/AdUITest.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
 
 import org.junit.After;
 import org.junit.Before;
@@ -25,6 +27,7 @@ import dagger.hilt.android.testing.UninstallModules;
 
 import static android.app.Activity.RESULT_CANCELED;
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -57,6 +60,8 @@ public class AdUITest {
     @Rule(order = 1)
     public ActivityScenarioRule<AdActivity> adActivityRule = new ActivityScenarioRule<>(intent);
 
+    UiDevice mDevice;
+
     @Before
     public void init() {
         Intents.init();
@@ -77,7 +82,8 @@ public class AdUITest {
 
     @Test
     public void clickOnGoBackFinishes() {
-        onView(withId(R.id.back_Ad_button)).perform(click());
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        mDevice.pressBack();
         assertEquals(adActivityRule.getScenario().getResult().getResultCode(), RESULT_CANCELED);
     }
 

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/PanoramaUITest.java
@@ -1,6 +1,8 @@
 package ch.epfl.sdp.appart;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,12 +19,14 @@ import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
 
+import static android.app.Activity.RESULT_CANCELED;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -66,6 +70,13 @@ public class PanoramaUITest {
         onView(withId(leftButtonID)).check(matches(not(isDisplayed())));
         onView(withId(rightButtonID)).check(matches(isDisplayed()));
 
+    }
+
+    @Test
+    public void backButtonTest(){
+        UiDevice mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        mDevice.pressBack();
+        assertEquals(panoramaActivityRule.getScenario().getResult().getResultCode(), RESULT_CANCELED);
     }
 
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/SimpleUserProfileActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/SimpleUserProfileActivityTest.java
@@ -20,6 +20,9 @@ import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.MockDatabaseService;
 import ch.epfl.sdp.appart.hilt.DatabaseModule;
@@ -28,6 +31,7 @@ import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
 
+import static android.app.Activity.RESULT_CANCELED;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
@@ -40,6 +44,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 @LargeTest
 @RunWith(AndroidJUnit4ClassRunner.class)
@@ -267,12 +272,13 @@ public class SimpleUserProfileActivityTest {
                         withParent(withParent(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class))),
                         isDisplayed()));
         button.check(matches(isDisplayed()));
+    }
 
-        ViewInteraction button2 = onView(
-                allOf(withId(R.id.back_SimpleUserProfile_button), withText("BACK"),
-                        withParent(withParent(withId(android.R.id.content))),
-                        isDisplayed()));
-        button2.check(matches(isDisplayed()));
+    @Test
+    public void backButtonPressedTest(){
+        UiDevice mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        mDevice.pressBack();
+        assertEquals(mActivityTestRule.getScenario().getResult().getResultCode(), RESULT_CANCELED);
     }
 
     private static Matcher<View> childAtPosition(

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/UserProfileActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/UserProfileActivityTest.java
@@ -414,13 +414,6 @@ public class UserProfileActivityTest {
                         withParent(withParent(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class))),
                         isDisplayed()));
         button.check(matches(isDisplayed()));
-
-        ViewInteraction button2 = onView(
-                allOf(withId(R.id.back_UserProfile_button), withText("BACK"),
-                        withParent(allOf(withId(R.id.infoLayout),
-                                withParent(withId(android.R.id.content)))),
-                        isDisplayed()));
-        button2.check(matches(isDisplayed()));
     }
 
     private static Matcher<View> childAtPosition(

--- a/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/AdActivity.java
@@ -133,19 +133,13 @@ public class AdActivity extends ToolbarActivity {
     }
 
     /**
-     * Method called when the activity is done and should be closed.
+     * Method called when the device back button is pressed.
      * <p>
-     * If the activity has been opened by AdCreationActivity, then it opens a new ScrollingActivity,
-     * otherwise it returns to the ScrollingActivity that opened this activity.
-     *
-     * @param view
+     * It goes back to the scrolling activity.
      */
-    public void goBack(View view) {
-        if (getIntent().getBooleanExtra("fromAdCreation", false)) {
-            startActivity(new Intent(this, ScrollingActivity.class));
-        } else {
-            finish();
-        }
+    @Override
+    public void onBackPressed() {
+        finish();
     }
 
     /**

--- a/app/src/main/java/ch/epfl/sdp/appart/PanoramaActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/PanoramaActivity.java
@@ -98,11 +98,10 @@ public class PanoramaActivity extends AppCompatActivity {
     }
 
     /**
-     * Method called when the activity is done and should be closed.
-     *
-     * @param view
+     * Method called when the device back button is tapped. It closes the activity.
      */
-    public void goBack(View view) {
+    @Override
+    public void onBackPressed() {
         finish();
     }
 

--- a/app/src/main/java/ch/epfl/sdp/appart/SimpleUserProfileActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/SimpleUserProfileActivity.java
@@ -25,7 +25,6 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
     UserViewModel mViewModel;
 
     /* UI components */
-    private Button backButton;
     private EditText nameText;
     private EditText ageText;
     private EditText phoneNumberText;
@@ -44,7 +43,6 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
 
 
         /* UI components initialisation */
-        this.backButton = findViewById(R.id.back_SimpleUserProfile_button);
         this.nameText = findViewById(R.id.name_SimpleUserProfile_editText);
         this.ageText = findViewById(R.id.age_SimpleUserProfile_editText);
         this.emailTextView = findViewById(R.id.emailText_SimpleUserProfile_textView);
@@ -59,12 +57,6 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
         mViewModel.getUser(advertiserId);
         mViewModel.getUser().observe(this, this::setAdUserToLocal);
     }
-
-
-    /**
-     *  closes activity when back button pressed on UI
-     */
-    public void goBack(View view) { finish(); }
 
     /**
      * closes activity when back button pressed on phone

--- a/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
@@ -37,7 +37,6 @@ public class UserProfileActivity extends AppCompatActivity {
     /* UI components */
     private Button modifyButton;
     private Button doneButton;
-    private Button backButton;
     private EditText nameEditText;
     private EditText ageEditText;
     private EditText phoneNumberEditText;
@@ -58,7 +57,6 @@ public class UserProfileActivity extends AppCompatActivity {
         /* UI components initialisation */
         this.modifyButton = findViewById(R.id.modifyButton);
         this.doneButton = findViewById(R.id.doneButton);
-        this.backButton = findViewById(R.id.back_UserProfile_button);
         this.nameEditText = findViewById(R.id.name_UserProfile_editText);
         this.ageEditText = findViewById(R.id.age_UserProfile_editText);
         this.emailTextView = findViewById(R.id.emailText_UserProfile_textView);
@@ -154,7 +152,6 @@ public class UserProfileActivity extends AppCompatActivity {
         this.nameEditText.setEnabled(!this.nameEditText.isEnabled());
         this.ageEditText.setEnabled(!this.ageEditText.isEnabled());
         this.genderSpinner.setEnabled(!this.genderSpinner.isEnabled());
-        this.backButton.setEnabled(!this.backButton.isEnabled());
         this.phoneNumberEditText.setEnabled(!this.phoneNumberEditText.isEnabled());
         /* email is never enabled since another process is required to edit it */
     }

--- a/app/src/main/res/layout/activity_announce.xml
+++ b/app/src/main/res/layout/activity_announce.xml
@@ -6,25 +6,12 @@
     android:layout_height="match_parent"
     tools:context=".AdActivity">
 
-    <ImageButton
-        android:id="@+id/back_Ad_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="56dp"
-        android:background="#00FFFFFF"
-        android:contentDescription="@string/backbutton_desc"
-        android:onClick="goBack"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@android:drawable/ic_menu_close_clear_cancel" />
-
     <TextView
         android:id="@+id/title_Ad_textView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="28dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:text="@string/default_loading"
         android:textAlignment="center"
@@ -32,7 +19,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/back_Ad_button" />
+        app:layout_constraintTop_toBottomOf="@+id/account_Ad_toolbar" />
 
     <ScrollView
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_simple_user_profile.xml
+++ b/app/src/main/res/layout/activity_simple_user_profile.xml
@@ -7,22 +7,6 @@
     tools:context=".SimpleUserProfileActivity">
 
 
-    <Button
-        android:id="@+id/back_SimpleUserProfile_button"
-        style="@style/Widget.AppCompat.Button.Small"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:contextClickable="true"
-        android:drawableStart="@drawable/back_action"
-        android:includeFontPadding="false"
-        android:onClick="goBack"
-        android:text="@string/backButtonText"
-        android:translationX="10dp"
-        android:translationY="10dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -8,22 +8,6 @@
     android:onClick="goBack"
     tools:context=".UserProfileActivity">
 
-    <Button
-        android:id="@+id/back_UserProfile_button"
-        style="@style/Widget.AppCompat.Button.Small"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:contextClickable="true"
-        android:drawableStart="@drawable/back_action"
-        android:includeFontPadding="false"
-        android:onClick="goBack"
-        android:text="@string/backButtonText"
-        android:translationX="10dp"
-        android:translationY="10dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/panoramagl.xml
+++ b/app/src/main/res/layout/panoramagl.xml
@@ -16,21 +16,6 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageButton
-            android:id="@+id/back_Panorama_button"
-            android:layout_width="84dp"
-            android:layout_height="98dp"
-            android:background="#00FFFFFF"
-            android:contentDescription="@string/backbutton_desc"
-            android:onClick="goBack"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0"
-            app:srcCompat="@android:drawable/ic_menu_close_clear_cancel" />
-
-        <ImageButton
             android:id="@+id/leftImage_Panorama_imageButton"
             android:layout_width="48dp"
             android:layout_height="43dp"

--- a/app/src/main/res/layout/photo_layout.xml
+++ b/app/src/main/res/layout/photo_layout.xml
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="300dp"
+    android:layout_height="300dp"
+    app:layout_constrainedHeight="true"
     android:elevation="6dp">
 
     <androidx.cardview.widget.CardView
-        android:layout_width="200dp"
-        android:layout_height="200dp"
-        app:cardCornerRadius="12dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:cardCornerRadius="24dp"
         app:cardElevation="6dp"
         app:layout_constraintDimensionRatio="1f"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <ImageView
-                android:id="@+id/photo_Photo_imageView"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:adjustViewBounds="true"
-                android:contentDescription="@string/photo_descprition"
-                android:scaleType="centerCrop"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintDimensionRatio="1f"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/apart_fake_image_1" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/photo_Photo_imageView"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/photo_descprition"
+            android:scaleType="centerCrop"
+            app:srcCompat="@drawable/apart_fake_image_1" />
     </androidx.cardview.widget.CardView>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR closes #157 .

It removes the back button from the activities to have a cleaner UI, and hence overrides the device back button to close the activity. It also modifies test classes accordingly.
It makes the ad photos a bit bigger.