### PR TITLE
Hotfix for layout of images in AdActivity

### DIFF
--- a/app/src/main/res/layout/photo_layout.xml
+++ b/app/src/main/res/layout/photo_layout.xml
@@ -2,14 +2,14 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="300dp"
-    android:layout_height="300dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     app:layout_constrainedHeight="true"
     android:elevation="6dp">
 
     <androidx.cardview.widget.CardView
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_width="300dp"
+        android:layout_height="300dp"
         app:cardCornerRadius="24dp"
         app:cardElevation="6dp"
         app:layout_constraintDimensionRatio="1f"


### PR DESCRIPTION
It fixes a small issue I didn't notice in my last PR. The wrong order of dimension constraints in the photo layout caused the images not to be shown once they were inserted in the linear layout of the ad activity.