### PR TITLE
Fix app crash on camera activity for API less than 29

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/appart/CameraActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/CameraActivity.java
@@ -32,6 +32,7 @@ import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.utils.ActivityCommunicationLayout;
 import ch.epfl.sdp.appart.utils.PermissionRequest;
 import dagger.hilt.android.AndroidEntryPoint;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +57,7 @@ public class CameraActivity extends AppCompatActivity {
 
     @Inject
     DatabaseService database;
-    
+
 
     @Override
     @SuppressWarnings("deprecation")
@@ -71,11 +72,9 @@ public class CameraActivity extends AppCompatActivity {
             Log.d("PERMISSION", "Camera permission refused");
             finish();
         });
-
-
     }
 
-    private void initActivity(){
+    private void initActivity() {
         listImageUri = new ArrayList<>();
         Intent intent = getIntent();
         activity = intent.getStringExtra(ActivityCommunicationLayout.PROVIDING_ACTIVITY_NAME);
@@ -92,12 +91,12 @@ public class CameraActivity extends AppCompatActivity {
         confirmBtn.setOnClickListener(v -> confirm());
     }
 
-    private void confirm(){
+    private void confirm() {
         if (imageUri == null) {
             Intent resultIntent = new Intent();
             setResult(RESULT_CANCELED, resultIntent);
             finish();
-            Toast.makeText(getApplicationContext(),R.string.canceledNoImage ,Toast.LENGTH_SHORT).show();
+            Toast.makeText(getApplicationContext(), R.string.canceledNoImage, Toast.LENGTH_SHORT).show();
         } else {
             if (activity.equals(ActivityCommunicationLayout.AD_CREATION_ACTIVITY)) {
                 Intent resultIntent = new Intent();
@@ -167,37 +166,39 @@ public class CameraActivity extends AppCompatActivity {
         }
     }
 
-    private void setDisplayAction(){
-        if(activity.equals(ActivityCommunicationLayout.AD_CREATION_ACTIVITY)) {
+    private void setDisplayAction() {
+        if (activity.equals(ActivityCommunicationLayout.AD_CREATION_ACTIVITY)) {
             displayListImage();
         } else if (activity.equals(ActivityCommunicationLayout.USER_PROFILE_ACTIVITY)) {
             displayImage();
         }
     }
 
-    private void displayImage(){
+    private void displayImage() {
         LinearLayout horizontalLayout = findViewById(R.id.image_Camera_linearLayout);
         horizontalLayout.removeAllViews();
         horizontalLayout.addView(uploadImage(imageUri));
     }
-    private void displayListImage(){
+
+    private void displayListImage() {
         listImageUri.add(imageUri);
         LinearLayout horizontalLayout = findViewById(R.id.image_Camera_linearLayout);
         horizontalLayout.removeAllViews();
-        for (Uri i: listImageUri) {
+        for (Uri i : listImageUri) {
             horizontalLayout.addView(uploadImage(i));
         }
     }
-    private View uploadImage(Uri uri){
+
+    private View uploadImage(Uri uri) {
         LayoutInflater inflater =
-            (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View myView = inflater.inflate(R.layout.photo_layout, (ViewGroup) null);
         ImageView photo = myView.findViewById(R.id.photo_Photo_imageView);
         photo.setImageURI(uri);
-        photo.setPadding(16,0,16,0);
+        photo.setPadding(16, 0, 16, 0);
         return myView;
     }
-    
+
     public void goBack(View view) {
         finish();
     }
@@ -207,7 +208,7 @@ public class CameraActivity extends AppCompatActivity {
         MimeTypeMap mime = MimeTypeMap.getSingleton();
         return mime.getExtensionFromMimeType(cR.getType(uri));
     }
-    
+
 }
 
 

--- a/app/src/main/java/ch/epfl/sdp/appart/CameraActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/CameraActivity.java
@@ -12,6 +12,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images.Media;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,6 +30,7 @@ import androidx.core.content.ContextCompat;
 
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.utils.ActivityCommunicationLayout;
+import ch.epfl.sdp.appart.utils.PermissionRequest;
 import dagger.hilt.android.AndroidEntryPoint;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +63,19 @@ public class CameraActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_camera);
+
+        PermissionRequest.askForCameraPermission(this, () -> {
+            Log.d("PERMISSION", "Camera permission granted");
+            initActivity();
+        }, () -> {
+            Log.d("PERMISSION", "Camera permission refused");
+            finish();
+        });
+
+
+    }
+
+    private void initActivity(){
         listImageUri = new ArrayList<>();
         Intent intent = getIntent();
         activity = intent.getStringExtra(ActivityCommunicationLayout.PROVIDING_ACTIVITY_NAME);
@@ -69,7 +84,7 @@ public class CameraActivity extends AppCompatActivity {
         Button galleryBtn = findViewById(R.id.gallery_Camera_button);
         Button confirmBtn = findViewById(R.id.confirm_Camera_button);
 
-        cameraBtn.setOnClickListener(w -> askCamPermission());
+        cameraBtn.setOnClickListener(w -> startCamera());
         galleryBtn.setOnClickListener((v) -> {
             Intent gallery = new Intent(Intent.ACTION_OPEN_DOCUMENT, Media.EXTERNAL_CONTENT_URI);
             startActivityForResult(gallery, GALLERY_REQUEST_CODE);
@@ -100,17 +115,6 @@ public class CameraActivity extends AppCompatActivity {
                 setResult(RESULT_OK, resultIntent);
                 finish();
             }
-        }
-    }
-
-    private void askCamPermission() {
-        if (ContextCompat.checkSelfPermission(this, permission.CAMERA)
-                != PackageManager.PERMISSION_GRANTED) {
-            //show popup to request permission
-            ActivityCompat
-                    .requestPermissions(this, new String[]{Manifest.permission.CAMERA}, CAMERA_PERM_CODE);
-        } else {
-            startCamera();
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/appart/utils/PermissionRequest.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/utils/PermissionRequest.java
@@ -3,6 +3,7 @@ package ch.epfl.sdp.appart.utils;
 import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.result.ActivityResultLauncher;
@@ -11,11 +12,10 @@ import androidx.core.app.ActivityCompat;
 
 public class PermissionRequest {
 
-
     public static void askForLocationPermission(Activity activity, Runnable permissionGranted, Runnable permissionRefused, Runnable educationalPopup) {
 
         ActivityResultLauncher<String[]> requestPermissionLauncher =
-                ((ComponentActivity)activity).registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(), isGranted -> {
+                ((ComponentActivity) activity).registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(), isGranted -> {
                     if (isGranted.get(Manifest.permission.ACCESS_COARSE_LOCATION) && isGranted.get(Manifest.permission.ACCESS_FINE_LOCATION)) {
                         //Continue app workfwlo
                         permissionGranted.run();
@@ -37,9 +37,68 @@ public class PermissionRequest {
                 //Ask permission
                 requestPermissionLauncher.launch(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION});
             }
-        }
-        else {
+        } else {
             permissionGranted.run();
         }
+    }
+
+    public static void askForCameraPermission(Activity activity, Runnable permissionGranted,
+                                              Runnable permissionRefused) {
+        ActivityResultLauncher<String[]> requestPermissionLauncher;
+        String[] permissions;
+
+
+        if (Build.VERSION.SDK_INT < 29) {
+            permissions = new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.CAMERA};
+        } else {
+            permissions = new String[]{
+                    Manifest.permission.CAMERA};
+        }
+
+        requestPermissionLauncher = resultLauncherFor(activity, permissionGranted,
+                permissionRefused, permissions);
+
+        if (!permissionsAlreadyGranted(activity, permissions)) {
+            requestPermissionLauncher.launch(permissions);
+        } else {
+            permissionGranted.run();
+        }
+    }
+
+    /**
+     * Returns an ActivityResultLauncher for the given permissions requests
+     */
+    private static ActivityResultLauncher<String[]> resultLauncherFor(Activity activity,
+                                                                      Runnable permissionGranted,
+                                                                      Runnable permissionRefused,
+                                                                      String... permissions){
+        return ((ComponentActivity) activity).registerForActivityResult(
+                new ActivityResultContracts.RequestMultiplePermissions(), isGranted -> {
+                    Boolean everythingGranted = true;
+                    for (int i = 0; i < permissions.length; i++){
+                        if (!isGranted.get(permissions[i])) everythingGranted = false;
+                    }
+                    if (everythingGranted){
+                        permissionGranted.run();
+                    } else {
+                        permissionRefused.run();
+                    }
+                });
+    }
+
+    /**
+     * Checks if the given permissions are granted, if not ask for them
+     */
+    private static boolean permissionsAlreadyGranted(Activity activity, String... permissions){
+        Boolean everythingGranted = true;
+        for (int i = 0; i < permissions.length; i++){
+            if (ActivityCompat.checkSelfPermission(activity, permissions[i])
+                    != PackageManager.PERMISSION_GRANTED){
+                everythingGranted = false;
+            }
+        }
+        return everythingGranted;
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/utils/PermissionRequest.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/utils/PermissionRequest.java
@@ -46,8 +46,7 @@ public class PermissionRequest {
                                               Runnable permissionRefused) {
         ActivityResultLauncher<String[]> requestPermissionLauncher;
         String[] permissions;
-
-
+        
         if (Build.VERSION.SDK_INT < 29) {
             permissions = new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
@@ -73,14 +72,14 @@ public class PermissionRequest {
     private static ActivityResultLauncher<String[]> resultLauncherFor(Activity activity,
                                                                       Runnable permissionGranted,
                                                                       Runnable permissionRefused,
-                                                                      String... permissions){
+                                                                      String... permissions) {
         return ((ComponentActivity) activity).registerForActivityResult(
                 new ActivityResultContracts.RequestMultiplePermissions(), isGranted -> {
                     Boolean everythingGranted = true;
-                    for (int i = 0; i < permissions.length; i++){
+                    for (int i = 0; i < permissions.length; i++) {
                         if (!isGranted.get(permissions[i])) everythingGranted = false;
                     }
-                    if (everythingGranted){
+                    if (everythingGranted) {
                         permissionGranted.run();
                     } else {
                         permissionRefused.run();
@@ -91,11 +90,11 @@ public class PermissionRequest {
     /**
      * Checks if the given permissions are granted, if not ask for them
      */
-    private static boolean permissionsAlreadyGranted(Activity activity, String... permissions){
+    private static boolean permissionsAlreadyGranted(Activity activity, String... permissions) {
         Boolean everythingGranted = true;
-        for (int i = 0; i < permissions.length; i++){
+        for (int i = 0; i < permissions.length; i++) {
             if (ActivityCompat.checkSelfPermission(activity, permissions[i])
-                    != PackageManager.PERMISSION_GRANTED){
+                    != PackageManager.PERMISSION_GRANTED) {
                 everythingGranted = false;
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the app run on devices with API level < 29 would crash when trying to open the camera.
This happened because starting API level 29 external storage permissions where automatically granted for a limited scope, so we weren't asking for them. The PR modifies the `PermissionRequest` class so that it also asks for external storage permissions when the API level is < 29.