### PR TITLE
User sync

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/appart/SimpleUserProfileActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/SimpleUserProfileActivityTest.java
@@ -22,36 +22,33 @@ import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.uiautomator.UiDevice;
 
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.MockDatabaseService;
+import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
+import ch.epfl.sdp.appart.database.local.MockLocalDatabase;
 import ch.epfl.sdp.appart.hilt.DatabaseModule;
+import ch.epfl.sdp.appart.hilt.LocalDatabaseModule;
 import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
 
-import static android.app.Activity.RESULT_CANCELED;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 
 @LargeTest
 @RunWith(AndroidJUnit4ClassRunner.class)
-@UninstallModules(DatabaseModule.class)
+@UninstallModules({DatabaseModule.class, LocalDatabaseModule.class})
 @HiltAndroidTest
 public class SimpleUserProfileActivityTest {
     @Rule(order = 0)
@@ -62,6 +59,8 @@ public class SimpleUserProfileActivityTest {
 
     @BindValue
     DatabaseService database = new MockDatabaseService();
+    @BindValue
+    LocalDatabaseService localdb = new MockLocalDatabase();
 
     @Before
     public void init() {

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
@@ -44,5 +44,10 @@ public class UserVMTest {
         assertEquals(user, vm.getUser().getValue());
     }
 
+    @Test
+    public void currentUserNullTest() {
+        assertTrue(vm.getCurrentUser().isCompletedExceptionally());
+    }
+
 
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
@@ -1,29 +1,20 @@
 package ch.epfl.sdp.appart;
 
-import android.graphics.Bitmap;
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import ch.epfl.sdp.appart.ad.Ad;
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.MockDatabaseService;
-import ch.epfl.sdp.appart.database.local.LocalDatabase;
 import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
+import ch.epfl.sdp.appart.database.local.MockLocalDatabase;
 import ch.epfl.sdp.appart.login.LoginService;
 import ch.epfl.sdp.appart.login.MockLoginService;
-import ch.epfl.sdp.appart.scrolling.card.Card;
 import ch.epfl.sdp.appart.user.AppUser;
 import ch.epfl.sdp.appart.user.User;
 import ch.epfl.sdp.appart.user.UserViewModel;
-import kotlin.NotImplementedError;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +26,7 @@ public class UserVMTest {
 
     DatabaseService db = new MockDatabaseService();
     LoginService ls = new MockLoginService();
-    LocalDatabaseService localDatabaseService = new MockLocalDBServiceForUserVM();
+    LocalDatabaseService localDatabaseService = new MockLocalDatabase();
 
     private UserViewModel vm;
 
@@ -46,69 +37,12 @@ public class UserVMTest {
 
     @Test
     public void putAndGetUserTest() {
-        User user = new AppUser("testId", "test@email.ch");
+        User user = new AppUser("vetterli-id", "vetterli@epfl.ch");
         vm.putUser(user);
         assertTrue(vm.getPutUserConfirmed().getValue());
-        vm.getUser("testId");
+        vm.getUser("vetterli-id");
         assertEquals(user, vm.getUser().getValue());
     }
 
 
-}
-
-class MockLocalDBServiceForUserVM implements LocalDatabaseService {
-
-    public MockLocalDBServiceForUserVM() {}
-
-    @Override
-    public User getCurrentUser() {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<Void> writeCompleteAd(String adId, String cardId, Ad ad, User user, List<Bitmap> adPhotos, List<Bitmap> panoramas, Bitmap profilePic) {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<List<Card>> getCards() {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<Ad> getAd(String adId) {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<User> getUser(String wantedUserID) {
-        CompletableFuture<User> result = new CompletableFuture<>();
-        result.complete(new AppUser("testId", "test@email.ch"));
-        return result;
-    }
-
-    @Override
-    public void cleanFavorites() {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public void removeCard(String cardId) {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<Void> setCurrentUser(User currentUser, Bitmap profilePic) {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public User loadCurrentUser() {
-        throw new NotImplementedError();
-    }
-
-    @Override
-    public CompletableFuture<List<String>> getPanoramasPaths(String adID) {
-        throw new NotImplementedError();
-    }
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/UserVMTest.java
@@ -1,5 +1,7 @@
 package ch.epfl.sdp.appart;
 
+import android.graphics.Bitmap;
+
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -7,15 +9,21 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import ch.epfl.sdp.appart.ad.Ad;
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.MockDatabaseService;
 import ch.epfl.sdp.appart.database.local.LocalDatabase;
 import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
 import ch.epfl.sdp.appart.login.LoginService;
 import ch.epfl.sdp.appart.login.MockLoginService;
+import ch.epfl.sdp.appart.scrolling.card.Card;
 import ch.epfl.sdp.appart.user.AppUser;
 import ch.epfl.sdp.appart.user.User;
 import ch.epfl.sdp.appart.user.UserViewModel;
+import kotlin.NotImplementedError;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -27,7 +35,7 @@ public class UserVMTest {
 
     DatabaseService db = new MockDatabaseService();
     LoginService ls = new MockLoginService();
-    LocalDatabaseService localDatabaseService = new LocalDatabase(InstrumentationRegistry.getInstrumentation().getTargetContext().getFilesDir().getPath());
+    LocalDatabaseService localDatabaseService = new MockLocalDBServiceForUserVM();
 
     private UserViewModel vm;
 
@@ -46,4 +54,61 @@ public class UserVMTest {
     }
 
 
+}
+
+class MockLocalDBServiceForUserVM implements LocalDatabaseService {
+
+    public MockLocalDBServiceForUserVM() {}
+
+    @Override
+    public User getCurrentUser() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Void> writeCompleteAd(String adId, String cardId, Ad ad, User user, List<Bitmap> adPhotos, List<Bitmap> panoramas, Bitmap profilePic) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<List<Card>> getCards() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Ad> getAd(String adId) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<User> getUser(String wantedUserID) {
+        CompletableFuture<User> result = new CompletableFuture<>();
+        result.complete(new AppUser("testId", "test@email.ch"));
+        return result;
+    }
+
+    @Override
+    public void cleanFavorites() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public void removeCard(String cardId) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Void> setCurrentUser(User currentUser, Bitmap profilePic) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public User loadCurrentUser() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getPanoramasPaths(String adID) {
+        throw new NotImplementedError();
+    }
 }

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/userui/UserProfileActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/userui/UserProfileActivityTest.java
@@ -1,4 +1,4 @@
-package ch.epfl.sdp.appart;
+package ch.epfl.sdp.appart.userui;
 
 import android.Manifest;
 import android.app.Instrumentation;
@@ -11,6 +11,7 @@ import android.view.ViewParent;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
@@ -25,6 +26,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.intent.Intents;
+import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
@@ -34,6 +36,9 @@ import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
+
+import ch.epfl.sdp.appart.MainActivity;
+import ch.epfl.sdp.appart.R;
 import ch.epfl.sdp.appart.database.DatabaseService;
 import ch.epfl.sdp.appart.database.MockDatabaseService;
 import ch.epfl.sdp.appart.database.preferences.SharedPreferencesHelper;
@@ -103,7 +108,7 @@ public class UserProfileActivityTest {
     @Test
     public void userProfileActivityTest() throws UiObjectNotFoundException {
         ViewInteraction appCompatEditText = onView(
-            allOf(withId(R.id.email_Login_editText),
+            Matchers.allOf(ViewMatchers.withId(R.id.email_Login_editText),
                 childAtPosition(
                     childAtPosition(
                         withId(android.R.id.content),

--- a/app/src/androidTest/java/ch/epfl/sdp/appart/userui/UserProfileExceptionallyTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/appart/userui/UserProfileExceptionallyTest.java
@@ -1,0 +1,97 @@
+package ch.epfl.sdp.appart.userui;
+
+import android.Manifest;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletableFuture;
+
+import ch.epfl.sdp.appart.MainActivity;
+import ch.epfl.sdp.appart.R;
+import ch.epfl.sdp.appart.UserProfileActivity;
+import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.database.MockDatabaseService;
+import ch.epfl.sdp.appart.database.exceptions.DatabaseServiceException;
+import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
+import ch.epfl.sdp.appart.database.local.MockLocalDatabase;
+import ch.epfl.sdp.appart.database.preferences.SharedPreferencesHelper;
+import ch.epfl.sdp.appart.hilt.DatabaseModule;
+import ch.epfl.sdp.appart.hilt.LoginModule;
+import ch.epfl.sdp.appart.login.LoginService;
+import ch.epfl.sdp.appart.login.MockLoginService;
+import ch.epfl.sdp.appart.user.UserViewModel;
+import dagger.hilt.android.testing.BindValue;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import dagger.hilt.android.testing.UninstallModules;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.not;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+@UninstallModules({LoginModule.class, DatabaseModule.class})
+@HiltAndroidTest
+public class UserProfileExceptionallyTest {
+
+    @Rule(order = 0)
+    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+    @Rule(order = 1)
+    public ActivityScenarioRule<UserProfileActivity> mActivityScenarioRule =
+            new ActivityScenarioRule<>(UserProfileActivity.class);
+
+    /* Used to grant camera permission always */
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION);
+
+    @BindValue
+    DatabaseService database = new MockDatabaseService();
+
+    @BindValue
+    LoginService login = new MockLoginService();
+
+    @BindValue
+    UserViewModel mViewModel = new MockUserViewModel(database, login, new MockLocalDatabase());
+
+    @Before
+    public void init() {
+        hiltRule.inject();
+    }
+
+    @Test
+    public void exceptionallyOnCreate() {
+        mActivityScenarioRule.getScenario().onActivity(ac -> {
+            SharedPreferencesHelper.clearSavedUserForAutoLogin(ac);
+            ac.recreate();
+        });
+        onView(withId(R.id.editProfile_UserProfile_button)).check(matches(not(isDisplayed())));
+    }
+}
+
+class MockUserViewModel extends UserViewModel {
+
+    public MockUserViewModel(DatabaseService database, LoginService loginService,
+                             LocalDatabaseService localdb) {
+        super(database, loginService, localdb);
+    }
+
+    @Override
+    public CompletableFuture<Void> getCurrentUser() {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        result.completeExceptionally(new DatabaseServiceException("fail"));
+        return result;
+    }
+
+}

--- a/app/src/main/java/ch/epfl/sdp/appart/LoginActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/LoginActivity.java
@@ -1,7 +1,6 @@
 package ch.epfl.sdp.appart;
 
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -9,8 +8,6 @@ import android.view.WindowManager;
 import android.widget.EditText;
 
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.google.firebase.auth.FirebaseAuthException;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/app/src/main/java/ch/epfl/sdp/appart/SimpleUserProfileActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/SimpleUserProfileActivity.java
@@ -1,6 +1,7 @@
 package ch.epfl.sdp.appart;
 
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.os.Bundle;
 
 import android.view.View;
@@ -11,11 +12,17 @@ import android.widget.TextView;
 import javax.inject.Inject;
 
 import androidx.lifecycle.ViewModelProvider;
+
+import java.util.concurrent.CompletableFuture;
+
 import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.database.local.LocalDatabase;
+import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
 import ch.epfl.sdp.appart.glide.visitor.GlideImageViewLoader;
 import ch.epfl.sdp.appart.user.User;
 import ch.epfl.sdp.appart.user.UserViewModel;
 import ch.epfl.sdp.appart.utils.ActivityCommunicationLayout;
+import ch.epfl.sdp.appart.utils.DatabaseSync;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
@@ -29,6 +36,8 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
 
     @Inject
     DatabaseService database;
+    @Inject
+    LocalDatabaseService localdb;
 
     /* UI components */
     private EditText nameText;
@@ -57,25 +66,27 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
         this.uniAccountClaimer = findViewById(R.id.uniAccountClaimer_SimpleUserProfile_textView);
         this.imageView = findViewById(R.id.profilePicture_SimpleUserProfile_imageView);
 
-        String advertiserId = getIntent().getStringExtra(ActivityCommunicationLayout.PROVIDING_USER_ID);
+        String advertiserId =
+                getIntent().getStringExtra(ActivityCommunicationLayout.PROVIDING_USER_ID);
 
         /* get user from database from user ID */
-        mViewModel.getUser(advertiserId);
+        CompletableFuture<Void> userRes = mViewModel.getUser(advertiserId);
+        userRes.thenAccept(res -> DatabaseSync.saveCurrentUserToLocalDB(this, database, localdb,
+                mViewModel.getUser().getValue().getUserId()));
         mViewModel.getUser().observe(this, this::setAdUserToLocal);
     }
 
     /**
-     *  closes activity when back button pressed on UI
+     * closes activity when back button pressed on UI
      */
     public void contactAdUser(View view) {
         // TODO: send message to user
     }
 
     /**
-     *
      * @param user sets the value of the current user to the session user object
      */
-    private void setAdUserToLocal(User user){
+    private void setAdUserToLocal(User user) {
         this.advertiserUser = user;
 
         /* set attributes of session user to the UI components */
@@ -88,7 +99,8 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
     private void getAndSetCurrentAttributes() {
         this.nameText.setText(this.advertiserUser.getName());
         this.emailTextView.setText(this.advertiserUser.getUserEmail());
-        this.uniAccountClaimer.setText((this.advertiserUser.hasUniversityEmail() ? getString(R.string.uniAccountClaimer) : getString(R.string.nonUniAccountClaimer)));
+        this.uniAccountClaimer.setText((this.advertiserUser.hasUniversityEmail() ?
+                getString(R.string.uniAccountClaimer) : getString(R.string.nonUniAccountClaimer)));
         if (this.advertiserUser.getAge() != 0) {
             this.ageText.setText(String.valueOf(this.advertiserUser.getAge()));
         }
@@ -108,5 +120,5 @@ public class SimpleUserProfileActivity extends AppCompatActivity {
         database.accept(new GlideImageViewLoader(this, imageView,
                 this.advertiserUser.getProfileImagePathAndName()));
     }
-    
+
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -30,6 +31,7 @@ import ch.epfl.sdp.appart.user.Gender;
 import ch.epfl.sdp.appart.user.User;
 import ch.epfl.sdp.appart.user.UserViewModel;
 import ch.epfl.sdp.appart.utils.ActivityCommunicationLayout;
+import ch.epfl.sdp.appart.utils.DatabaseSync;
 import ch.epfl.sdp.appart.utils.UIUtils;
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -92,7 +94,15 @@ public class UserProfileActivity extends AppCompatActivity {
         this.changeImageButton.setVisibility(View.GONE);
 
         /* get user from database from user ID */
-        mViewModel.getCurrentUser();
+        CompletableFuture<Void> userRes = mViewModel.getCurrentUser();
+        userRes.exceptionally(e -> {
+            Log.d("USER", "Failed to fetch user from DB");
+            return null;
+        });
+        userRes.thenAccept(res -> {
+            DatabaseSync.saveCurrentUserToLocalDB(this, database, localdb,
+                    mViewModel.getUser().getValue().getUserId());
+        });
         mViewModel.getUser().observe(this, this::setSessionUserToLocal);
     }
 

--- a/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/UserProfileActivity.java
@@ -97,15 +97,13 @@ public class UserProfileActivity extends AppCompatActivity {
         CompletableFuture<Void> userRes = mViewModel.getCurrentUser();
         // if user successfully fetched from DB, save it locally
         userRes.exceptionally(e -> {
-            Log.d("USER", "Failed to fetch user from DB");
             // failed to fetch -> prevent updated (we're probably offline)
             modifyButton.setVisibility(View.GONE);
             return null;
         });
-        userRes.thenAccept(res -> {
-            DatabaseSync.saveCurrentUserToLocalDB(this, database, localdb,
-                    mViewModel.getUser().getValue().getUserId());
-        });
+        userRes.thenAccept(res ->
+                DatabaseSync.saveCurrentUserToLocalDB(this, database, localdb,
+                        mViewModel.getUser().getValue().getUserId()));
         mViewModel.getUser().observe(this, this::setSessionUserToLocal);
     }
 

--- a/app/src/main/java/ch/epfl/sdp/appart/database/local/MockLocalDatabase.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/local/MockLocalDatabase.java
@@ -1,0 +1,89 @@
+package ch.epfl.sdp.appart.database.local;
+
+import android.graphics.Bitmap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Singleton;
+
+import ch.epfl.sdp.appart.ad.Ad;
+import ch.epfl.sdp.appart.database.exceptions.DatabaseServiceException;
+import ch.epfl.sdp.appart.scrolling.card.Card;
+import ch.epfl.sdp.appart.user.AppUser;
+import ch.epfl.sdp.appart.user.User;
+import kotlin.NotImplementedError;
+
+@Singleton
+public class MockLocalDatabase implements LocalDatabaseService {
+
+    Map<String,User> users;
+
+    public MockLocalDatabase() {
+        users = new HashMap<>();
+        User vetterli = new AppUser("vetterli-id", "veterli@epfl.ch");
+        vetterli.setName("Martin Vetterli");
+        vetterli.setAge(40);
+        vetterli.setGender("MALE");
+        vetterli.setPhoneNumber("0777777777");
+        users.put("vetterli-id", vetterli);
+    }
+
+    @Override
+    public User getCurrentUser() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Void> writeCompleteAd(String adId, String cardId, Ad ad, User user,
+                                                   List<Bitmap> adPhotos, List<Bitmap> panoramas,
+                                                   Bitmap profilePic) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<List<Card>> getCards() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Ad> getAd(String adId) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<User> getUser(String wantedUserID) {
+        CompletableFuture<User> result = new CompletableFuture<>();
+        if (wantedUserID.equals("vetterli-id")) result.complete(
+                users.get("vetterli-id"));
+        else result.completeExceptionally(new DatabaseServiceException("User not in db"));
+        return result;
+    }
+
+    @Override
+    public void cleanFavorites() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public void removeCard(String cardId) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<Void> setCurrentUser(User currentUser, Bitmap profilePic) {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public User loadCurrentUser() {
+        throw new NotImplementedError();
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getPanoramasPaths(String adID) {
+        throw new NotImplementedError();
+    }
+}

--- a/app/src/main/java/ch/epfl/sdp/appart/database/local/MockLocalDatabase.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/local/MockLocalDatabase.java
@@ -33,7 +33,7 @@ public class MockLocalDatabase implements LocalDatabaseService {
 
     @Override
     public User getCurrentUser() {
-        throw new NotImplementedError();
+        return null;
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sdp/appart/user/UserViewModel.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/user/UserViewModel.java
@@ -138,7 +138,7 @@ public class UserViewModel extends ViewModel {
      */
     public CompletableFuture<Void> getCurrentUser() {
         CompletableFuture<Void> result = new CompletableFuture<>();
-        User currentUser = localdb.loadCurrentUser();
+        User currentUser = localdb.getCurrentUser();
         if (currentUser != null)
             mUser.setValue(currentUser);
 

--- a/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
@@ -6,7 +6,9 @@ import android.graphics.Bitmap;
 import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.database.local.LocalDatabaseService;
 import ch.epfl.sdp.appart.glide.visitor.GlideBitmapLoader;
+import ch.epfl.sdp.appart.user.User;
 
 /**
  * Util class used for operations commonly needed when dealing with synchronization of the local
@@ -27,5 +29,45 @@ public class DatabaseSync {
         CompletableFuture<Bitmap> imgRes = new CompletableFuture<>();
         db.accept(new GlideBitmapLoader(context, imgRes, userImgPath));
         return imgRes;
+    }
+
+    /**
+     * Fetches the user and their profile picture from the server, saves the info to the local
+     * database.
+     * @param context the context to use with Glide
+     * @param db database service from which the user and their profile image is fetched
+     * @param ldb local database service to which the info is saved
+     * @param userId id of the user to save
+     * @return a completable future telling whether the operation was successful
+     */
+    public static CompletableFuture<Void> saveCurrentUserToLocalDB(Context context,
+                                                                   DatabaseService db,
+                                                                   LocalDatabaseService ldb,
+                                                                   String userId){
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        CompletableFuture<User> userRes = db.getUser(userId);
+        userRes.exceptionally(e -> {
+            result.completeExceptionally(e);
+            return null;
+        });
+        userRes.thenAccept(u -> {
+            CompletableFuture<Bitmap> pfpRes = getUserProfilePicture(context,
+                    db, u.getProfileImagePathAndName());
+            pfpRes.exceptionally(e -> {
+                result.completeExceptionally(e);
+                return null;
+            });
+            pfpRes.thenAccept(img -> {
+                CompletableFuture<Void> saveRes = ldb.setCurrentUser(u, img);
+                saveRes.exceptionally(e -> {
+                    result.completeExceptionally(e);
+                    return null;
+                });
+                saveRes.thenAccept(res -> {
+                    result.complete(null);
+                });
+            });
+        });
+        return result;
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
@@ -1,0 +1,31 @@
+package ch.epfl.sdp.appart.utils;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import java.util.concurrent.CompletableFuture;
+
+import ch.epfl.sdp.appart.database.DatabaseService;
+import ch.epfl.sdp.appart.glide.visitor.GlideBitmapLoader;
+
+/**
+ * Util class used for operations commonly needed when dealing with synchronization of the local
+ * database with the server.
+ */
+public class DatabaseSync {
+
+    /**
+     * Fetches the user's profile picture from the server
+     *
+     * @param context the context to use with Glide
+     * @param db      database service from which we fetch the image
+     * @return a completable future with the image as bitmap
+     */
+    public static CompletableFuture<Bitmap> getUserProfilePicture(Context context,
+                                                                  DatabaseService db,
+                                                                  String userImgPath) {
+        CompletableFuture<Bitmap> imgRes = new CompletableFuture<>();
+        db.accept(new GlideBitmapLoader(context, imgRes, userImgPath));
+        return imgRes;
+    }
+}

--- a/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/utils/DatabaseSync.java
@@ -2,6 +2,7 @@ package ch.epfl.sdp.appart.utils;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.util.Log;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -61,9 +62,11 @@ public class DatabaseSync {
                 CompletableFuture<Void> saveRes = ldb.setCurrentUser(u, img);
                 saveRes.exceptionally(e -> {
                     result.completeExceptionally(e);
+                    Log.d("SYNC", "Failed to save locally");
                     return null;
                 });
                 saveRes.thenAccept(res -> {
+                    Log.d("SYNC", "user saved locally");
                     result.complete(null);
                 });
             });

--- a/app/src/test/java/ch/epfl/sdp/appart/MockLocalDatabaseTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/MockLocalDatabaseTest.java
@@ -1,0 +1,112 @@
+package ch.epfl.sdp.appart;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import ch.epfl.sdp.appart.database.local.MockLocalDatabase;
+import ch.epfl.sdp.appart.user.AppUser;
+import ch.epfl.sdp.appart.user.User;
+import kotlin.NotImplementedError;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class MockLocalDatabaseTest {
+
+    private AppUser vetterli;
+    private MockLocalDatabase localdb;
+
+    @Before
+    public void init() {
+        localdb = new MockLocalDatabase();
+        vetterli = new AppUser("vetterli-id", "vetterli@epfl.ch");
+        vetterli.setName("Martin Vetterli");
+        vetterli.setAge(40);
+        vetterli.setGender("MALE");
+        vetterli.setPhoneNumber("0777777777");
+    }
+
+    @Test
+    public void getCurrentUserThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.getCurrentUser();
+        });
+    }
+
+    @Test
+    public void writeCompleteAdThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.writeCompleteAd(null, null, null, null, null, null, null);
+        });
+    }
+
+    @Test
+    public void getCardsThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.getCards();
+        });
+    }
+
+    @Test
+    public void getAdThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.getAd(null);
+        });
+    }
+
+    @Test
+    public void getUserWorksForGoodValue() throws ExecutionException, InterruptedException {
+        assertEquals(vetterli.getUserId(),
+                localdb.getUser("vetterli-id").get().getUserId());
+    }
+
+    @Test
+    public void getUserWorksForBadValue() {
+        CompletableFuture<User> res = localdb.getUser("");
+        res.exceptionally(e -> {
+            assertTrue(true);
+            return null;
+        });
+        res.thenAccept(u -> assertTrue(false));
+    }
+
+    @Test
+    public void cleanFavoritesThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.cleanFavorites();
+        });
+    }
+
+    @Test
+    public void removeCardThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.removeCard("");
+        });
+    }
+
+    @Test
+    public void setCurrentUserThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.setCurrentUser(null, null);
+        });
+    }
+
+    @Test
+    public void loadCurrentThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.loadCurrentUser();
+        });
+    }
+
+    @Test
+    public void getPanoramasPathsThrows() {
+        assertThrows(NotImplementedError.class, () -> {
+            localdb.getPanoramasPaths(null);
+        });
+    }
+}
+

--- a/app/src/test/java/ch/epfl/sdp/appart/MockLocalDatabaseTest.java
+++ b/app/src/test/java/ch/epfl/sdp/appart/MockLocalDatabaseTest.java
@@ -12,6 +12,7 @@ import ch.epfl.sdp.appart.user.User;
 import kotlin.NotImplementedError;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -31,10 +32,8 @@ public class MockLocalDatabaseTest {
     }
 
     @Test
-    public void getCurrentUserThrows() {
-        assertThrows(NotImplementedError.class, () -> {
-            localdb.getCurrentUser();
-        });
+    public void getCurrentUserReturnsNull() {
+        assertNull(localdb.getCurrentUser());
     }
 
     @Test
@@ -66,12 +65,7 @@ public class MockLocalDatabaseTest {
 
     @Test
     public void getUserWorksForBadValue() {
-        CompletableFuture<User> res = localdb.getUser("");
-        res.exceptionally(e -> {
-            assertTrue(true);
-            return null;
-        });
-        res.thenAccept(u -> assertTrue(false));
+        assertTrue(localdb.getUser("").isCompletedExceptionally());
     }
 
     @Test


### PR DESCRIPTION
This PR partly addresses #176 .

It adds the logic to save the current user after successful login to the server, and loads that info when opening the user profile activity. Also, when opening User and SimpleUser activities, it loads first from local DB and then from the server. If the fetch from server is successful, it updates the locally saved data about the user.