### PR TITLE
Fix ad not loading

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/appart/ad/AdViewModel.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/ad/AdViewModel.java
@@ -32,11 +32,16 @@ public class AdViewModel extends ViewModel {
     private final MutableLiveData<String> adTitle = new MutableLiveData<>();
     private final MutableLiveData<String> adAddress = new MutableLiveData<>();
     private final MutableLiveData<String> adPrice = new MutableLiveData<>();
-    private final MutableLiveData<String> adDescription = new MutableLiveData<>();
-    private final MutableLiveData<String> adAdvertiserName = new MutableLiveData<>();
-    private final MutableLiveData<String> adAdvertiserId = new MutableLiveData<>();
-    private final MutableLiveData<List<String>> adPhotosReferences = new MutableLiveData<>();
-    private final MutableLiveData<List<String>> panoramasReferences = new MutableLiveData<>();
+    private final MutableLiveData<String> adDescription =
+            new MutableLiveData<>();
+    private final MutableLiveData<String> adAdvertiserName =
+            new MutableLiveData<>();
+    private final MutableLiveData<String> adAdvertiserId =
+            new MutableLiveData<>();
+    private final MutableLiveData<List<String>> adPhotosReferences =
+            new MutableLiveData<>();
+    private final MutableLiveData<List<String>> panoramasReferences =
+            new MutableLiveData<>();
 
     @Inject
     public AdViewModel(DatabaseService db, LocalDatabaseService localdb) {
@@ -45,11 +50,14 @@ public class AdViewModel extends ViewModel {
     }
 
     /**
-     * Loads and sets ad info from the local database. It then tries to fetch the ad info from
-     * the database. If successful, sets the ad info with the new data form the server.
+     * Loads and sets ad info from the local database. It then tries to fetch
+     * the ad info from
+     * the database. If successful, sets the ad info with the new data form
+     * the server.
      *
      * @param id the unique ID of the ad in the database
-     * @return a completable future that is normally completed if the server fetch was successful
+     * @return a completable future that is normally completed if the server
+     * fetch was successful
      */
     public CompletableFuture<Void> initAd(String id) {
         CompletableFuture<Void> result = new CompletableFuture<>();
@@ -57,8 +65,9 @@ public class AdViewModel extends ViewModel {
         return result;
     }
 
-    public <T> void observePanoramasReferences(LifecycleOwner owner, @NonNull Observer<?
-            super List<String>> observer) {
+    public <T> void observePanoramasReferences(LifecycleOwner owner,
+                                               @NonNull Observer<?
+                                                       super List<String>> observer) {
         panoramasReferences.observe(owner, observer);
     }
 
@@ -97,7 +106,8 @@ public class AdViewModel extends ViewModel {
     }
 
     /**
-     * Loads the ad data from the local database and sets the values to mutablelivedata fields.
+     * Loads the ad data from the local database and sets the values to
+     * mutablelivedata fields.
      */
     private CompletableFuture<Void> localLoad(String adId) {
         CompletableFuture<Void> result = new CompletableFuture<>();
@@ -115,16 +125,37 @@ public class AdViewModel extends ViewModel {
     /**
      * Helper to set values from an ad
      */
-    private void setAdValues(CompletableFuture<Void> result, CompletableFuture<Ad> adRes) {
+    private void setAdValues(CompletableFuture<Void> result,
+                             CompletableFuture<Ad> adRes) {
         adRes.exceptionally(e -> {
             result.completeExceptionally(e);
             return null;
         });
         adRes.thenAccept(ad -> {
+            /*
+            If the ad is null then the ad isn't stored locally --> it is
+            not on disk
+            Having a null ad here probably caused a NullPointerException, and
+             since this is executed in another
+            thread, it just disappeared... And therefore, the future was
+            never completed,
+            which resulted in fetchAndSet never being called.
+            If an ad is null, we can just complete with null directly.
+            We could also modify the behavior of the get in the local
+            database to maybe
+            complete exceptionally when an id is not present in the data
+            structure.
+            However, this is probably the simplest solution.
+            */
+            if (ad == null) {
+                result.complete(null);
+                return;
+            }
             this.ad = ad;
             this.adAddress.setValue(addressFrom(ad.getStreet(), ad.getCity()));
             this.adTitle.setValue(ad.getTitle());
-            this.adPrice.setValue(priceFrom(ad.getPrice(), ad.getPricePeriod()));
+            this.adPrice.setValue(priceFrom(ad.getPrice(),
+                    ad.getPricePeriod()));
             this.adDescription.setValue(ad.getDescription());
             this.adAdvertiserName.setValue(ad.getAdvertiserName());
             this.adAdvertiserId.setValue(ad.getAdvertiserId());


### PR DESCRIPTION
This PR aims at fixing the ad sometimes not loading in the scrolling activity. This was due to a behavior in the local database not very well documented. When you want to get something that is not present on disk from the db, it returns null. However, in the AdViewModel the ad was not checked for null causing probably (because I am not sure) a NullPointerException. Since, the building of the ad happens in another thread, this didn't cause the app to crash but only the thread to be "descheduled" preventing from completing a future. The execution of the fetch from the server (where we are sure the ad is stored) only happened if the aforementioned future was completed. The fix is a simple null check on the ad. We could also change the behavior of the local database when something that is not available is requested. Tell me what do you think.