### PR TITLE
Exception handling for databases

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/appart/database/local/LocalDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/local/LocalDatabaseService.java
@@ -20,7 +20,7 @@ public interface LocalDatabaseService {
      * @return the current user if it manages to find one, throws
      * {@link IllegalStateException} otherwise.
      */
-    User getCurrentUser();
+    User getCurrentUser() throws IllegalStateException;
 
     /**
      * This function performs the writing of a complete ad into local storage
@@ -55,7 +55,7 @@ public interface LocalDatabaseService {
      *
      * @return a completable future containing the list of cards
      */
-    CompletableFuture<List<Card>> getCards();
+    CompletableFuture<List<Card>> getCards() throws IllegalStateException;
 
     /**
      * Returns an ad with ad id.

--- a/app/src/main/java/ch/epfl/sdp/appart/database/local/LocalDatabaseService.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/database/local/LocalDatabaseService.java
@@ -55,7 +55,7 @@ public interface LocalDatabaseService {
      *
      * @return a completable future containing the list of cards
      */
-    CompletableFuture<List<Card>> getCards() throws IllegalStateException;
+    CompletableFuture<List<Card>> getCards();
 
     /**
      * Returns an ad with ad id.

--- a/app/src/main/java/ch/epfl/sdp/appart/glide/visitor/GlideBitmapLoader.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/glide/visitor/GlideBitmapLoader.java
@@ -47,6 +47,7 @@ public class GlideBitmapLoader extends GlideVisitor implements GlideBitmapLoader
         Glide.with(context)
                 .asBitmap()
                 .load(database.getStorageReference(imagePath))
+                .error(R.drawable.no_connection)
                 .into(target);
     }
 

--- a/app/src/main/java/ch/epfl/sdp/appart/user/UserViewModel.java
+++ b/app/src/main/java/ch/epfl/sdp/appart/user/UserViewModel.java
@@ -138,7 +138,14 @@ public class UserViewModel extends ViewModel {
      */
     public CompletableFuture<Void> getCurrentUser() {
         CompletableFuture<Void> result = new CompletableFuture<>();
-        User currentUser = localdb.getCurrentUser();
+        User currentUser;
+        try {
+            currentUser = localdb.getCurrentUser();
+        } catch (IllegalStateException e){
+            e.printStackTrace();
+            currentUser = null;
+        }
+
         if (currentUser != null)
             mUser.setValue(currentUser);
 


### PR DESCRIPTION
This fix aims at correctly handling exceptions thrown by the local database and operations on storagereferences so that the app doesn't crash in case of failure.

In the case of the local db an `IllegalStateException` is thrown when a call to `getCurrentUser` happens while the currentUser is not stored on disk. I modified the internal calls in the localdb so that it return an exceptionally completed future if it catches this exception. In the UserViewModel, if we catch an exception then we do not set user values and proceed to the firebase call.

In the case of storagereferences, I added to the glide bitmap loader an `.error` call so that if the storagereference task fails then we load a default bitmap.

A quick app testing showed me that the issues are solved, but to be 100% sure we would need to use the app a lot more.

**REMARK** needs #245 to be merged before this.