### PR TITLE
Bookmark icon, white title text

### DIFF
--- a/app/src/main/res/drawable/ic_bookmark.xml
+++ b/app/src/main/res/drawable/ic_bookmark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="@android:color/white">
+    <path android:fillColor="@android:color/white"
+        android:pathData="M17,3L7,3c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3L19,5c0,-1.1 -0.9,-2 -2,-2zM17,18l-5,-2.18L7,18L7,5h10v13z"/>
+</vector>

--- a/app/src/main/res/layout/activity_announce.xml
+++ b/app/src/main/res/layout/activity_announce.xml
@@ -218,7 +218,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:subtitleTextColor="#FFFFFF "
-        app:titleTextColor="#FFFFFF "/>
+        app:titleTextColor="@android:color/white"/>
 
     <androidx.constraintlayout.widget.Guideline
       android:id="@+id/guideline_add1"

--- a/app/src/main/res/layout/activity_scrolling.xml
+++ b/app/src/main/res/layout/activity_scrolling.xml
@@ -71,7 +71,7 @@
       app:layout_constraintTop_toTopOf="parent"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
       app:subtitleTextColor="#FFFFFF "
-      app:titleTextColor="#FFFFFF " />
+      app:titleTextColor="@android:color/white"/>
 
     <androidx.constraintlayout.widget.Guideline
       android:id="@+id/guideline7"

--- a/app/src/main/res/layout/activity_user_ads.xml
+++ b/app/src/main/res/layout/activity_user_ads.xml
@@ -16,7 +16,8 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
-      app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+      app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:titleTextColor="@android:color/white"/>
 
     <LinearLayout
       android:id="@+id/columnLayout_Scrolling_LinearLayout"

--- a/app/src/main/res/menu/ad_toolbar.xml
+++ b/app/src/main/res/menu/ad_toolbar.xml
@@ -4,7 +4,7 @@
 
     <item
         android:id="@+id/action_add_favorite"
-        android:icon="@drawable/favorite_button"
+        android:icon="@drawable/ic_bookmark"
         android:title="@string/add_to_favorites"
         app:showAsAction="ifRoom" />
 


### PR DESCRIPTION
This PR changes the star icon with a bookmark icon, and sets the 'AppArt' text to white in the various toolbars.

A nice addition would be to change the bookmark icon to a filled version if the ad is bookmarked, but I don't think we have the time to do it. I'll still add a card on the release sprint under the minor changes.